### PR TITLE
Bug fix + asm support

### DIFF
--- a/languages/vscode_filetypes.py
+++ b/languages/vscode_filetypes.py
@@ -65,5 +65,6 @@ vim2vscode = {
     'vue': 'vue',
     'xml': 'xml',
     'yaml': 'yaml',
-    'zsh': 'shellscript'
+    'zsh': 'shellscript',
+    'asm': 'asm-intel-x86-generic'
 }

--- a/scripts/ultisnips_to_vscode
+++ b/scripts/ultisnips_to_vscode
@@ -87,7 +87,7 @@ def extend(ultisnips_file):
         for line in f:
             if line.startswith('extends'):
                 scopes = line.split()[1].strip().split(',')
-                scopes = [base / f'{s}.snippets' for s in scopes]
+                scopes = [base / f'{s}.snippets' for s in scopes if s]
     return scopes
 
 


### PR DESCRIPTION
The first commit is about adding asm snippets.

The second one is about fixing a bug that generated an empty .snippets file and threw the following error

```
Traceback (most recent call last):
  File "/home/user/.local/bin/ultisnips_to_vscode", line 126, in <module>
    main()
  File "/home/user/.local/bin/ultisnips_to_vscode", line 117, in main
    snippets_dictionary =  make_big_dict(scopes)
  File "/home/user/.local/bin/ultisnips_to_vscode", line 98, in make_big_dict
    big_dict.update(ultisnips_to_dict(file))
  File "/home/user/.local/bin/ultisnips_to_vscode", line 42, in ultisnips_to_dict
    with open(ultisnips_file, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.vim/plugged/vim-snippets/UltiSnips/.snippets'
```
Notice the last line.